### PR TITLE
WD-75 ajax host is provided as env variable when running app inside

### DIFF
--- a/src/server/lib/config.js
+++ b/src/server/lib/config.js
@@ -1,7 +1,8 @@
 const config = {
   Ajax: {
-    // using the local ip of the machine
-    host: 'http://192.168.43.47:5000',
+    // env variable `AJAX_HOST` provided when running docker
+    // containers
+    host: process.env.AJAX_HOST ? process.env.AJAX_HOST : 'http://localhost:5000',
   },
 };
 


### PR DESCRIPTION
#### Link to Jira ticket

https://harshverma.atlassian.net/browse/WD-75
#### Summary (optional, depending on complexity of the change)
- If running app inside a docker container, then `AJAX_HOST` env variable needs to passed
- Otherwise, defaults to `localhost`
#### Reviewer:
- [ ] Unit tests
- [ ] Sufficient documentation

docker container, otherwise defaults to localhost
